### PR TITLE
[Docs] Remove ref to cSpell

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ The only thing that really matters here is the [`package.json`](/package.json). 
 - [Live Share](https://marketplace.visualstudio.com/items?itemName=MS-vsliveshare.vsliveshare)
 - [Live Share Audio](https://marketplace.visualstudio.com/items?itemName=MS-vsliveshare.vsliveshare-audio)
 - [Gremlins](https://github.com/nhoizey/vscode-gremlins) (highlights unwanted characters in code)
-- [Code Spell Checker](https://github.com/Jason-Rev/vscode-spell-checker)
 - [TODO: Highlight](https://marketplace.visualstudio.com/items?itemName=wayou.vscode-todo-highlight)
 - [Open in GitHub](https://marketplace.visualstudio.com/items?itemName=ziyasal.vscode-open-in-github)
 


### PR DESCRIPTION
Was removed in https://github.com/artsy/vscode-artsy/commit/ffc3516dd3732afd11688ecbae4ea1f7153748fe