### PR TITLE
Revert switch to vscode apollo fork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Change Log
 
-# 1.3.1
-
-Switch to use our fork of vscode-apollo while we wait for movement on https://github.com/apollographql/apollo-tooling/pull/800 - alloy
-
 # 1.3.0
 
 - Adds stylelint extension - [see the RFC](https://github.com/artsy/vscode-artsy/issues/2 ) orta 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "jpoissonnier.vscode-styled-components", 
         "mikestead.dotenv", 
         "ms-vscode.typescript-javascript-grammar", 
-        "Artsy.vscode-apollo",
+        "apollographql.vscode-apollo",
         "vsmobile.vscode-react-native", 
         "shinnn.stylelint",
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "artsy-studio-extension-pack",
     "displayName": "Artsy Omakase Extension Pack",
     "description": "The Artsy recommended extensions for working in our front-end/platform stacks",
-    "version": "1.3.1",
+    "version": "1.3.0",
     "publisher": "Artsy",
     "preview": true,
     "repository": {


### PR DESCRIPTION
As discussed, seeing as vscode isn’t great in swapping out extensions we’re not going to do this right away.