### PR TITLE
chore: clean up frontend extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+# 1.4.0
+
+- Remove storybook extension - mounir
+- Remove ios-common-files extension - mounir
+- Add relay extension - mounir
+- Replace tslint with eslint - mounir
+
 # 1.3.1
 
 - Removes unneeded extension that was causing problems - ash

--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ The only thing that really matters here is the [`package.json`](/package.json). 
 - [Styled Components](https://marketplace.visualstudio.com/items?itemName=jpoissonnier.vscode-styled-components)
 - [Dotenv](https://github.com/mikestead/vscode-dotenv)
 - [GraphQL](https://github.com/apollographql/apollo-tooling)
+- [Relay](https://marketplace.visualstudio.com/items?itemName=meta.relay)
 - [NPM intellisense](https://marketplace.visualstudio.com/items?itemName=christian-kohler.npm-intellisense)
-- [TSLint](https://marketplace.visualstudio.com/items?itemName=eg2.tslint)
+- [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
 - [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)
 - [stylelint](https://marketplace.visualstudio.com/items?itemName=shinnn.stylelint)
 - [TypeScript Grammar](https://marketplace.visualstudio.com/items?itemName=ms-vscode.typescript-javascript-grammar)
@@ -34,8 +35,6 @@ The only thing that really matters here is the [`package.json`](/package.json). 
 ### React Native
 
 - [React Native Tools](https://marketplace.visualstudio.com/items?itemName=vsmobile.vscode-react-native)
-- [React Native Storybooks](https://marketplace.visualstudio.com/items?itemName=Orta.vscode-react-native-storybooks)
-- [iOS Common Files](https://marketplace.visualstudio.com/items?itemName=Orta.vscode-ios-common-files)
 
 ### Ruby 
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "artsy-studio-extension-pack",
     "displayName": "Artsy Omakase Extension Pack",
     "description": "The Artsy recommended extensions for working in our front-end/platform stacks",
-    "version": "1.3.1",
+    "version": "1.4.0",
     "publisher": "Artsy",
     "preview": true,
     "repository": {

--- a/package.json
+++ b/package.json
@@ -22,11 +22,9 @@
         "misogi.ruby-rubocop", 
         "rebornix.ruby", 
 
-        "mjmcloug.vscode-elixir", 
 
         "jpoissonnier.vscode-styled-components", 
         "mikestead.dotenv", 
-        "apollographql.vscode-apollo",
         "vsmobile.vscode-react-native", 
         "shinnn.stylelint",
 

--- a/package.json
+++ b/package.json
@@ -24,9 +24,6 @@
 
         "mjmcloug.vscode-elixir", 
 
-        "Orta.vscode-react-native-storybooks", 
-        "Orta.vscode-ios-common-files", 
-
         "jpoissonnier.vscode-styled-components", 
         "mikestead.dotenv", 
         "apollographql.vscode-apollo",
@@ -34,7 +31,6 @@
         "shinnn.stylelint",
 
         "christian-kohler.npm-intellisense", 
-        "eg2.tslint", 
         "esbenp.prettier-vscode", 
 
         "ms-vsliveshare.vsliveshare", 
@@ -45,6 +41,10 @@
 
         "nhoizey.gremlins", 
         "wayou.vscode-todo-highlight", 
-        "ziyasal.vscode-open-in-github"
+        "ziyasal.vscode-open-in-github",
+
+        "dbaeumer.vscode-eslint",
+        "meta.relay"
+
     ]
 }

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,9 @@
+### Description
+This PR makes the following change(s):
+- 
+
+### PR Checklist
+
+- [ ] I added my changes to `CHANGELOG.md`
+- [ ] I updated the list of the extensions in `Readme.md`
+- [ ] I updated `package.json` version number


### PR DESCRIPTION
This PR makes the following changes:
- Remove `tslint` in favor of `eslint`, which is what we use currently for all our projects currently I believe(at least the active ones)
- Remove legacy RN extensions
  - Common Files doesn't make sense here because ruby styling does that, it makes more sense if we didn't have ruby styling
  - The storybook extension is not working anymore (glad to try this again if someone thinks it's worth it)
- Add Relay Graphql extension 
![Screenshot 2024-01-03 at 11 07 16](https://github.com/artsy/vscode-artsy/assets/11945712/b1290c68-c0ed-4338-b396-ca0c27e120a5)

___
**Bonus:**
- I added a PR template to make sure whoever works on this next doesn't miss making similar changes in the future (comments are welcome about its format and content)