### PR TITLE
chore: add pretty typescript errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Change Log
+# 1.5.0
+
+- Add Pretty Typescript Errors extension - mounir
 
 # 1.4.0
 
@@ -40,6 +43,7 @@ Initial commit, adds:
 - [TSLint](https://marketplace.visualstudio.com/items?itemName=eg2.tslint)
 - [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)
 - [TypeScript Grammar](https://marketplace.visualstudio.com/items?itemName=ms-vscode.typescript-javascript-grammar)
+- [Pretty TypeScript Errors](https://marketplace.visualstudio.com/items?itemName=yoavbls.pretty-ts-errors)
 
 ### React Native
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The only thing that really matters here is the [`package.json`](/package.json). 
 
 ## Deployment
 
+### Using the terminal
 The docs from Microsoft are good here, use [them for reference](https://code.visualstudio.com/docs/extensions/publish-extension#_login-to-a-publisher).
 
 1. You will need to set up a visualstudio.com account
@@ -81,6 +82,22 @@ The docs from Microsoft are good here, use [them for reference](https://code.vis
 
 1. Change the package.json version number
 1. Run `npx vsce publish`
+
+### Using the Visual Studio Marketplace 
+
+1. Connect to mobile@ Visual Studio account. 
+2. Navigate to the directory of the extension
+3. Run `npx vsce package`. This will create a `.vsix` file in the root of the extension directory
+4. Go to the [marketplace](https://marketplace.visualstudio.com/manage/publishers/artsy). Tap on the Meatballs Icon (...) next to to `Artsy Omakase Extension Pack` and click `Update`.
+5. Select the `.vsix` file you just created.
+
+It should take only a few minutes for the extension to be published. 
+
+<details>
+<summary>Publishing an update</summary>
+
+  ![publishing-an-update](./screenshots/publishing_an_update.gif/)
+</details>
 
 ## Adding More People to Deploy
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The only thing that really matters here is the [`package.json`](/package.json). 
 - [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)
 - [stylelint](https://marketplace.visualstudio.com/items?itemName=shinnn.stylelint)
 - [TypeScript Grammar](https://marketplace.visualstudio.com/items?itemName=ms-vscode.typescript-javascript-grammar)
+- [Pretty TypeScript Errors](https://marketplace.visualstudio.com/items?itemName=yoavbls.pretty-ts-errors)
 
 ### React Native
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "artsy-studio-extension-pack",
     "displayName": "Artsy Omakase Extension Pack",
     "description": "The Artsy recommended extensions for working in our front-end/platform stacks",
-    "version": "1.4.0",
+    "version": "1.5.0",
     "publisher": "Artsy",
     "preview": true,
     "repository": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
         "ziyasal.vscode-open-in-github",
 
         "dbaeumer.vscode-eslint",
-        "meta.relay"
+        "meta.relay",
 
+        "yoavbls.pretty-ts-errors"
     ]
 }


### PR DESCRIPTION
### Description
This PR makes the following changes:
- add pretty typescript errors
- Add additional docs on how to publish because the documented approach is not possible and I couldn't get permissions.

<img width="734" alt="Screenshot 2024-06-17 at 11 07 13" src="https://github.com/artsy/vscode-artsy/assets/11945712/6507596a-4e7c-47e6-8a8c-10b317d06c88">

### PR Checklist

- [x] I added my changes to `CHANGELOG.md`
- [x] I updated the list of the extensions in `Readme.md`
- [x] I updated `package.json` version number
