### PR TITLE
chore: add biome extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 # 1.5.0
 
+- Add Biome extension - mounir
+
+# 1.5.0
+
 - Add Pretty Typescript Errors extension - mounir
 
 # 1.4.0

--- a/README.md
+++ b/README.md
@@ -22,16 +22,17 @@ The only thing that really matters here is the [`package.json`](/package.json). 
 
 #### Artsy Studio
 
-- [Styled Components](https://marketplace.visualstudio.com/items?itemName=jpoissonnier.vscode-styled-components)
+- [Biome](https://marketplace.visualstudio.com/items?itemName=biomejs.biome)
 - [Dotenv](https://github.com/mikestead/vscode-dotenv)
-- [GraphQL](https://github.com/apollographql/apollo-tooling)
-- [Relay](https://marketplace.visualstudio.com/items?itemName=meta.relay)
-- [NPM intellisense](https://marketplace.visualstudio.com/items?itemName=christian-kohler.npm-intellisense)
 - [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
+- [GraphQL](https://github.com/apollographql/apollo-tooling)
+- [NPM intellisense](https://marketplace.visualstudio.com/items?itemName=christian-kohler.npm-intellisense)
 - [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)
+- [Pretty TypeScript Errors](https://marketplace.visualstudio.com/items?itemName=yoavbls.pretty-ts-errors)
+- [Relay](https://marketplace.visualstudio.com/items?itemName=meta.relay)
+- [Styled Components](https://marketplace.visualstudio.com/items?itemName=jpoissonnier.vscode-styled-components)
 - [stylelint](https://marketplace.visualstudio.com/items?itemName=shinnn.stylelint)
 - [TypeScript Grammar](https://marketplace.visualstudio.com/items?itemName=ms-vscode.typescript-javascript-grammar)
-- [Pretty TypeScript Errors](https://marketplace.visualstudio.com/items?itemName=yoavbls.pretty-ts-errors)
 
 ### React Native
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "artsy-studio-extension-pack",
     "displayName": "Artsy Omakase Extension Pack",
     "description": "The Artsy recommended extensions for working in our front-end/platform stacks",
-    "version": "1.5.0",
+    "version": "1.6.0",
     "publisher": "Artsy",
     "preview": true,
     "repository": {
@@ -44,6 +44,8 @@
         "dbaeumer.vscode-eslint",
         "meta.relay",
 
-        "yoavbls.pretty-ts-errors"
+        "yoavbls.pretty-ts-errors",
+
+        "biomejs.biome"
     ]
 }


### PR DESCRIPTION
### Description
This PR makes the following change(s):
- add biome extension. Follow-up on https://github.com/artsy/force/pull/15041/files#r1894416594

The authentication here is pretty weird. I added some [docs](https://github.com/artsy/vscode-artsy/pull/11/commits/7dbe15407cf518574f9407835e0b2f16a75e968c) a few months ago to help with that. Unfortunately I was only able to update the extension manually through the website instead of the terminal.

<img width="1307" alt="Screenshot 2025-01-06 at 14 59 17" src="https://github.com/user-attachments/assets/0123d2ab-1854-42d5-857c-57d617cf8703" />


### PR Checklist

- [x] I added my changes to `CHANGELOG.md`
- [x] I updated the list of the extensions in `Readme.md`
- [x] I updated `package.json` version number
